### PR TITLE
fix: SSE dashboard refresh renders HTML instead of literal text

### DIFF
--- a/docs/plans/2026-03-06-sse-refresh-design.md
+++ b/docs/plans/2026-03-06-sse-refresh-design.md
@@ -1,0 +1,40 @@
+# SSE Dashboard Refresh Fix
+
+## Problem
+
+After each poll tick, the orchestrator broadcasts `Broadcast("agent-update", "refresh")`. The dashboard uses `sse-swap="agent-update"`, which tells HTMX to replace the div's innerHTML with the SSE event data — the literal string "refresh". The entire dashboard is replaced with the text "REFRESH".
+
+## Solution
+
+Use the SSE event as a trigger for an `hx-get` request instead of `sse-swap`. The event signals "something changed"; a separate HTTP endpoint returns the rendered HTML fragment.
+
+## Design
+
+### Template changes (`dashboard.templ`)
+
+Extract the dashboard inner content into a `DashboardContent` component. The full `Dashboard` renders the layout wrapper + SSE div + initial content. `DashboardContent` renders just the cards and tables (the swappable fragment).
+
+Change the SSE div from:
+```html
+<div hx-ext="sse" sse-connect="/api/v1/events" sse-swap="agent-update">
+```
+to:
+```html
+<div hx-ext="sse" sse-connect="/api/v1/events" hx-trigger="sse:agent-update" hx-get="/api/v1/dashboard">
+```
+
+### New endpoint (`server.go`)
+
+Add `GET /api/v1/dashboard` that renders `DashboardContent` with current state data (running agents, retries, planning, metrics, max agents). Uses the same state/metrics/retry providers already wired into the server.
+
+### No changes needed
+
+- `sse.go` — unchanged
+- `orchestrator.go` — broadcast calls remain as-is; the data payload is ignored by the client
+
+## Files
+
+| File | Change |
+|------|--------|
+| `internal/web/templates/pages/dashboard.templ` | Extract `DashboardContent` component, update SSE div attributes |
+| `internal/web/server.go` | Add `GET /api/v1/dashboard` handler |

--- a/docs/plans/2026-03-06-sse-refresh-plan.md
+++ b/docs/plans/2026-03-06-sse-refresh-plan.md
@@ -1,0 +1,122 @@
+# SSE Dashboard Refresh Fix — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix the dashboard SSE refresh so it swaps in rendered HTML instead of displaying the literal text "refresh".
+
+**Architecture:** Change from `sse-swap` (which replaces innerHTML with event data) to `hx-trigger="sse:agent-update"` + `hx-get="/api/v1/dashboard"` (which triggers an HTTP fetch on SSE event). Extract dashboard inner content into a `DashboardContent` component so the fragment endpoint can render it independently.
+
+**Tech Stack:** templ, HTMX SSE extension, chi router
+
+---
+
+### Task 1: Extract DashboardContent component
+
+**Files:**
+- Modify: `internal/web/templates/pages/dashboard.templ`
+
+**Step 1: Edit the templ file**
+
+Split the existing `Dashboard` component. Extract everything inside the `<div hx-ext="sse" ...>` into a new `DashboardContent` component. Update the SSE div to use `hx-trigger` + `hx-get` instead of `sse-swap`.
+
+In `dashboard.templ`, the `Dashboard` component becomes:
+
+```templ
+templ Dashboard(running []*domain.RunEntry, retries []*domain.RetryEntry, planning []*domain.PlanningEntry, metrics map[string]int64, maxAgents int) {
+	@layouts.Base("Dashboard") {
+		<div hx-ext="sse" sse-connect="/api/v1/events" hx-trigger="sse:agent-update" hx-get="/api/v1/dashboard">
+			@DashboardContent(running, retries, planning, metrics, maxAgents)
+		</div>
+	}
+}
+```
+
+Add a new `DashboardContent` component containing everything that was previously inside the SSE div (summary cards, active agents table, planning table, retry queue table). Same signature, just the inner HTML.
+
+**Step 2: Regenerate templ**
+
+Run: `task generate`
+Expected: Clean exit, `dashboard_templ.go` regenerated.
+
+**Step 3: Verify it compiles**
+
+Run: `go build ./internal/web/...`
+Expected: No errors.
+
+**Step 4: Commit**
+
+```bash
+git add internal/web/templates/pages/dashboard.templ internal/web/templates/pages/dashboard_templ.go
+git commit -m "refactor: extract DashboardContent component for SSE fragment"
+```
+
+---
+
+### Task 2: Add dashboard fragment endpoint
+
+**Files:**
+- Modify: `internal/web/server.go:72-80` (add route)
+- Modify: `internal/web/server.go` (add handler method)
+
+**Step 1: Add the route and handler**
+
+In `buildRouter()`, add inside the `/api/v1` route group (after the existing `/events` line):
+
+```go
+r.Get("/dashboard", s.handleDashboardFragment)
+```
+
+Add the handler method. It mirrors `handleDashboardPage` but renders only `DashboardContent` (no layout wrapper):
+
+```go
+func (s *Server) handleDashboardFragment(w http.ResponseWriter, r *http.Request) {
+	running := s.state.AllRunning()
+	var retries []*domain.RetryEntry
+	if s.retries != nil {
+		retries = s.retries.All()
+	}
+	var planningEntries []*domain.PlanningEntry
+	if s.planning != nil {
+		planningEntries = s.planning.AllPlanning()
+	}
+	m := map[string]int64{}
+	if s.metrics != nil {
+		m = s.metrics.All()
+	}
+	component := pages.DashboardContent(running, retries, planningEntries, m, s.cfg.Polling.MaxConcurrentAgents)
+	component.Render(r.Context(), w)
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `go build ./...`
+Expected: No errors.
+
+**Step 3: Commit**
+
+```bash
+git add internal/web/server.go
+git commit -m "feat: add /api/v1/dashboard fragment endpoint for SSE refresh"
+```
+
+---
+
+### Task 3: Smoke test
+
+**Step 1: Run existing tests**
+
+Run: `task test`
+Expected: All tests pass.
+
+**Step 2: Manual verification**
+
+Run: `task dev`
+
+1. Open `http://localhost:<port>/` in browser
+2. Open browser DevTools → Network tab
+3. Verify SSE connection to `/api/v1/events` is established
+4. Wait for a poll tick
+5. Verify: SSE event `agent-update` arrives, triggers GET `/api/v1/dashboard`, dashboard content swaps in without showing "REFRESH" text
+
+**Step 3: Commit (if any fixes needed)**

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -74,6 +74,7 @@ func (s *Server) buildRouter() chi.Router {
 		r.Get("/state", s.handleState)
 		r.Get("/metrics", s.handleMetrics)
 		r.Get("/events", s.sseHub.HandleSSE)
+		r.Get("/dashboard", s.handleDashboardFragment)
 		r.Get("/issues/{owner}/{repo}/{id}", s.handleIssueDetailAPI)
 		r.Get("/sprint", s.handleSprintAPI)
 		r.Post("/refresh", s.handleRefresh)
@@ -135,6 +136,24 @@ func (s *Server) handleDashboardPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	component := pages.Dashboard(running, retries, planningEntries, m, s.cfg.Polling.MaxConcurrentAgents)
+	component.Render(r.Context(), w)
+}
+
+func (s *Server) handleDashboardFragment(w http.ResponseWriter, r *http.Request) {
+	running := s.state.AllRunning()
+	var retries []*domain.RetryEntry
+	if s.retries != nil {
+		retries = s.retries.All()
+	}
+	var planningEntries []*domain.PlanningEntry
+	if s.planning != nil {
+		planningEntries = s.planning.AllPlanning()
+	}
+	m := map[string]int64{}
+	if s.metrics != nil {
+		m = s.metrics.All()
+	}
+	component := pages.DashboardContent(running, retries, planningEntries, m, s.cfg.Polling.MaxConcurrentAgents)
 	component.Render(r.Context(), w)
 }
 

--- a/internal/web/templates/pages/dashboard.templ
+++ b/internal/web/templates/pages/dashboard.templ
@@ -9,137 +9,141 @@ import (
 
 templ Dashboard(running []*domain.RunEntry, retries []*domain.RetryEntry, planning []*domain.PlanningEntry, metrics map[string]int64, maxAgents int) {
 	@layouts.Base("Dashboard") {
-		<div hx-ext="sse" sse-connect="/api/v1/events" sse-swap="agent-update">
-			<!-- Summary Cards -->
-			<div class="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6" id="summary-cards">
-				@SummaryCard("Active Agents", fmt.Sprintf("%d / %d", len(running), maxAgents))
-				@SummaryCard("Planning", fmt.Sprintf("%d", len(planning)))
-				@SummaryCard("Dispatched", fmt.Sprintf("%d", metrics["issues_dispatched"]))
-				@SummaryCard("Completed", fmt.Sprintf("%d", metrics["issues_completed"]))
-				@SummaryCard("Failed", fmt.Sprintf("%d", metrics["issues_failed"]))
-			</div>
-
-			<!-- Active Agents Table -->
-			<div class="bg-white dark:bg-gray-800 rounded-lg shadow mb-6">
-				<div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
-					<h2 class="text-lg font-semibold">Active Agents</h2>
-				</div>
-				<div class="overflow-x-auto">
-					<table class="w-full text-sm">
-						<thead class="bg-gray-50 dark:bg-gray-700">
-							<tr>
-								<th class="px-4 py-2 text-left">Issue</th>
-								<th class="px-4 py-2 text-left">Repo</th>
-								<th class="px-4 py-2 text-left">Status</th>
-								<th class="px-4 py-2 text-left">Duration</th>
-								<th class="px-4 py-2 text-left">Attempt</th>
-								<th class="px-4 py-2 text-left">Last Activity</th>
-							</tr>
-						</thead>
-						<tbody>
-							if len(running) == 0 {
-								<tr>
-									<td colspan="6" class="px-4 py-8 text-center text-gray-500">No active agents</td>
-								</tr>
-							}
-							for _, entry := range running {
-								<tr class="border-t border-gray-200 dark:border-gray-700">
-									<td class="px-4 py-2">
-										<a href={ templ.SafeURL(fmt.Sprintf("/issues/%s/%d", entry.Issue.Repo, entry.Issue.ID)) } class="text-blue-500 hover:underline">
-											{ entry.Issue.Identifier() }
-										</a>
-									</td>
-									<td class="px-4 py-2">{ entry.Issue.Repo }</td>
-									<td class="px-4 py-2">
-										<span class="px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">Running</span>
-									</td>
-									<td class="px-4 py-2">{ FormatDuration(entry.Duration()) }</td>
-									<td class="px-4 py-2">{ fmt.Sprintf("%d", entry.Attempt) }</td>
-									<td class="px-4 py-2">{ entry.LastEventAt.Format("15:04:05") }</td>
-								</tr>
-							}
-						</tbody>
-					</table>
-				</div>
-			</div>
-
-			<!-- Planning Sessions Table -->
-			<div class="bg-white dark:bg-gray-800 rounded-lg shadow mb-6">
-				<div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
-					<h2 class="text-lg font-semibold">Planning Sessions</h2>
-				</div>
-				<div class="overflow-x-auto">
-					<table class="w-full text-sm">
-						<thead class="bg-gray-50 dark:bg-gray-700">
-							<tr>
-								<th class="px-4 py-2 text-left">Issue</th>
-								<th class="px-4 py-2 text-left">Repo</th>
-								<th class="px-4 py-2 text-left">Status</th>
-								<th class="px-4 py-2 text-left">Phase</th>
-								<th class="px-4 py-2 text-left">Questions Asked</th>
-							</tr>
-						</thead>
-						<tbody>
-							if len(planning) == 0 {
-								<tr>
-									<td colspan="5" class="px-4 py-8 text-center text-gray-500">No active planning sessions</td>
-								</tr>
-							}
-							for _, entry := range planning {
-								<tr class="border-t border-gray-200 dark:border-gray-700">
-									<td class="px-4 py-2">
-										<a href={ templ.SafeURL(fmt.Sprintf("/issues/%s/%d", entry.Repo, entry.IssueID)) } class="text-blue-500 hover:underline">
-											{ entry.Identifier() }
-										</a>
-									</td>
-									<td class="px-4 py-2">{ entry.Repo }</td>
-									<td class="px-4 py-2">
-										<span class="px-2 py-1 text-xs font-medium rounded-full bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">Planning</span>
-									</td>
-									<td class="px-4 py-2">{ entry.Phase }</td>
-									<td class="px-4 py-2">{ fmt.Sprintf("%d", entry.QuestionsAsked) }</td>
-								</tr>
-							}
-						</tbody>
-					</table>
-				</div>
-			</div>
-
-			<!-- Retry Queue Table -->
-			<div class="bg-white dark:bg-gray-800 rounded-lg shadow">
-				<div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
-					<h2 class="text-lg font-semibold">Retry Queue</h2>
-				</div>
-				<div class="overflow-x-auto">
-					<table class="w-full text-sm">
-						<thead class="bg-gray-50 dark:bg-gray-700">
-							<tr>
-								<th class="px-4 py-2 text-left">Issue</th>
-								<th class="px-4 py-2 text-left">Attempt</th>
-								<th class="px-4 py-2 text-left">Next Retry</th>
-								<th class="px-4 py-2 text-left">Error</th>
-							</tr>
-						</thead>
-						<tbody>
-							if len(retries) == 0 {
-								<tr>
-									<td colspan="4" class="px-4 py-8 text-center text-gray-500">No retries queued</td>
-								</tr>
-							}
-							for _, entry := range retries {
-								<tr class="border-t border-gray-200 dark:border-gray-700">
-									<td class="px-4 py-2">{ entry.Identifier }</td>
-									<td class="px-4 py-2">{ fmt.Sprintf("%d", entry.Attempt) }</td>
-									<td class="px-4 py-2">{ entry.DueAt.Format("15:04:05") }</td>
-									<td class="px-4 py-2 text-red-500">{ entry.Error }</td>
-								</tr>
-							}
-						</tbody>
-					</table>
-				</div>
-			</div>
+		<div hx-ext="sse" sse-connect="/api/v1/events" hx-trigger="sse:agent-update" hx-get="/api/v1/dashboard">
+			@DashboardContent(running, retries, planning, metrics, maxAgents)
 		</div>
 	}
+}
+
+templ DashboardContent(running []*domain.RunEntry, retries []*domain.RetryEntry, planning []*domain.PlanningEntry, metrics map[string]int64, maxAgents int) {
+	<!-- Summary Cards -->
+	<div class="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6" id="summary-cards">
+		@SummaryCard("Active Agents", fmt.Sprintf("%d / %d", len(running), maxAgents))
+		@SummaryCard("Planning", fmt.Sprintf("%d", len(planning)))
+		@SummaryCard("Dispatched", fmt.Sprintf("%d", metrics["issues_dispatched"]))
+		@SummaryCard("Completed", fmt.Sprintf("%d", metrics["issues_completed"]))
+		@SummaryCard("Failed", fmt.Sprintf("%d", metrics["issues_failed"]))
+	</div>
+
+	<!-- Active Agents Table -->
+	<div class="bg-white dark:bg-gray-800 rounded-lg shadow mb-6">
+		<div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+			<h2 class="text-lg font-semibold">Active Agents</h2>
+		</div>
+		<div class="overflow-x-auto">
+			<table class="w-full text-sm">
+				<thead class="bg-gray-50 dark:bg-gray-700">
+					<tr>
+						<th class="px-4 py-2 text-left">Issue</th>
+						<th class="px-4 py-2 text-left">Repo</th>
+						<th class="px-4 py-2 text-left">Status</th>
+						<th class="px-4 py-2 text-left">Duration</th>
+						<th class="px-4 py-2 text-left">Attempt</th>
+						<th class="px-4 py-2 text-left">Last Activity</th>
+					</tr>
+				</thead>
+				<tbody>
+					if len(running) == 0 {
+						<tr>
+							<td colspan="6" class="px-4 py-8 text-center text-gray-500">No active agents</td>
+						</tr>
+					}
+					for _, entry := range running {
+						<tr class="border-t border-gray-200 dark:border-gray-700">
+							<td class="px-4 py-2">
+								<a href={ templ.SafeURL(fmt.Sprintf("/issues/%s/%d", entry.Issue.Repo, entry.Issue.ID)) } class="text-blue-500 hover:underline">
+									{ entry.Issue.Identifier() }
+								</a>
+							</td>
+							<td class="px-4 py-2">{ entry.Issue.Repo }</td>
+							<td class="px-4 py-2">
+								<span class="px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">Running</span>
+							</td>
+							<td class="px-4 py-2">{ FormatDuration(entry.Duration()) }</td>
+							<td class="px-4 py-2">{ fmt.Sprintf("%d", entry.Attempt) }</td>
+							<td class="px-4 py-2">{ entry.LastEventAt.Format("15:04:05") }</td>
+						</tr>
+					}
+				</tbody>
+			</table>
+		</div>
+	</div>
+
+	<!-- Planning Sessions Table -->
+	<div class="bg-white dark:bg-gray-800 rounded-lg shadow mb-6">
+		<div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+			<h2 class="text-lg font-semibold">Planning Sessions</h2>
+		</div>
+		<div class="overflow-x-auto">
+			<table class="w-full text-sm">
+				<thead class="bg-gray-50 dark:bg-gray-700">
+					<tr>
+						<th class="px-4 py-2 text-left">Issue</th>
+						<th class="px-4 py-2 text-left">Repo</th>
+						<th class="px-4 py-2 text-left">Status</th>
+						<th class="px-4 py-2 text-left">Phase</th>
+						<th class="px-4 py-2 text-left">Questions Asked</th>
+					</tr>
+				</thead>
+				<tbody>
+					if len(planning) == 0 {
+						<tr>
+							<td colspan="5" class="px-4 py-8 text-center text-gray-500">No active planning sessions</td>
+						</tr>
+					}
+					for _, entry := range planning {
+						<tr class="border-t border-gray-200 dark:border-gray-700">
+							<td class="px-4 py-2">
+								<a href={ templ.SafeURL(fmt.Sprintf("/issues/%s/%d", entry.Repo, entry.IssueID)) } class="text-blue-500 hover:underline">
+									{ entry.Identifier() }
+								</a>
+							</td>
+							<td class="px-4 py-2">{ entry.Repo }</td>
+							<td class="px-4 py-2">
+								<span class="px-2 py-1 text-xs font-medium rounded-full bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">Planning</span>
+							</td>
+							<td class="px-4 py-2">{ entry.Phase }</td>
+							<td class="px-4 py-2">{ fmt.Sprintf("%d", entry.QuestionsAsked) }</td>
+						</tr>
+					}
+				</tbody>
+			</table>
+		</div>
+	</div>
+
+	<!-- Retry Queue Table -->
+	<div class="bg-white dark:bg-gray-800 rounded-lg shadow">
+		<div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+			<h2 class="text-lg font-semibold">Retry Queue</h2>
+		</div>
+		<div class="overflow-x-auto">
+			<table class="w-full text-sm">
+				<thead class="bg-gray-50 dark:bg-gray-700">
+					<tr>
+						<th class="px-4 py-2 text-left">Issue</th>
+						<th class="px-4 py-2 text-left">Attempt</th>
+						<th class="px-4 py-2 text-left">Next Retry</th>
+						<th class="px-4 py-2 text-left">Error</th>
+					</tr>
+				</thead>
+				<tbody>
+					if len(retries) == 0 {
+						<tr>
+							<td colspan="4" class="px-4 py-8 text-center text-gray-500">No retries queued</td>
+						</tr>
+					}
+					for _, entry := range retries {
+						<tr class="border-t border-gray-200 dark:border-gray-700">
+							<td class="px-4 py-2">{ entry.Identifier }</td>
+							<td class="px-4 py-2">{ fmt.Sprintf("%d", entry.Attempt) }</td>
+							<td class="px-4 py-2">{ entry.DueAt.Format("15:04:05") }</td>
+							<td class="px-4 py-2 text-red-500">{ entry.Error }</td>
+						</tr>
+					}
+				</tbody>
+			</table>
+		</div>
+	</div>
 }
 
 templ SummaryCard(title, value string) {

--- a/internal/web/templates/pages/dashboard_templ.go
+++ b/internal/web/templates/pages/dashboard_templ.go
@@ -48,280 +48,317 @@ func Dashboard(running []*domain.RunEntry, retries []*domain.RetryEntry, plannin
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div hx-ext=\"sse\" sse-connect=\"/api/v1/events\" sse-swap=\"agent-update\"><!-- Summary Cards --><div class=\"grid grid-cols-1 md:grid-cols-5 gap-4 mb-6\" id=\"summary-cards\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div hx-ext=\"sse\" sse-connect=\"/api/v1/events\" hx-trigger=\"sse:agent-update\" hx-get=\"/api/v1/dashboard\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = SummaryCard("Active Agents", fmt.Sprintf("%d / %d", len(running), maxAgents)).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = DashboardContent(running, retries, planning, metrics, maxAgents).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = SummaryCard("Planning", fmt.Sprintf("%d", len(planning))).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = SummaryCard("Dispatched", fmt.Sprintf("%d", metrics["issues_dispatched"])).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = SummaryCard("Completed", fmt.Sprintf("%d", metrics["issues_completed"])).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = SummaryCard("Failed", fmt.Sprintf("%d", metrics["issues_failed"])).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><!-- Active Agents Table --><div class=\"bg-white dark:bg-gray-800 rounded-lg shadow mb-6\"><div class=\"px-4 py-3 border-b border-gray-200 dark:border-gray-700\"><h2 class=\"text-lg font-semibold\">Active Agents</h2></div><div class=\"overflow-x-auto\"><table class=\"w-full text-sm\"><thead class=\"bg-gray-50 dark:bg-gray-700\"><tr><th class=\"px-4 py-2 text-left\">Issue</th><th class=\"px-4 py-2 text-left\">Repo</th><th class=\"px-4 py-2 text-left\">Status</th><th class=\"px-4 py-2 text-left\">Duration</th><th class=\"px-4 py-2 text-left\">Attempt</th><th class=\"px-4 py-2 text-left\">Last Activity</th></tr></thead> <tbody>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if len(running) == 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<tr><td colspan=\"6\" class=\"px-4 py-8 text-center text-gray-500\">No active agents</td></tr>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			for _, entry := range running {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<tr class=\"border-t border-gray-200 dark:border-gray-700\"><td class=\"px-4 py-2\"><a href=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var3 templ.SafeURL
-				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("/issues/%s/%d", entry.Issue.Repo, entry.Issue.ID)))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 48, Col: 97}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" class=\"text-blue-500 hover:underline\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var4 string
-				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Issue.Identifier())
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 49, Col: 37}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</a></td><td class=\"px-4 py-2\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var5 string
-				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Issue.Repo)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 52, Col: 49}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</td><td class=\"px-4 py-2\"><span class=\"px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200\">Running</span></td><td class=\"px-4 py-2\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var6 string
-				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(FormatDuration(entry.Duration()))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 56, Col: 65}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</td><td class=\"px-4 py-2\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var7 string
-				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.Attempt))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 57, Col: 65}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</td><td class=\"px-4 py-2\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var8 string
-				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(entry.LastEventAt.Format("15:04:05"))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 58, Col: 69}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</td></tr>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</tbody></table></div></div><!-- Planning Sessions Table --><div class=\"bg-white dark:bg-gray-800 rounded-lg shadow mb-6\"><div class=\"px-4 py-3 border-b border-gray-200 dark:border-gray-700\"><h2 class=\"text-lg font-semibold\">Planning Sessions</h2></div><div class=\"overflow-x-auto\"><table class=\"w-full text-sm\"><thead class=\"bg-gray-50 dark:bg-gray-700\"><tr><th class=\"px-4 py-2 text-left\">Issue</th><th class=\"px-4 py-2 text-left\">Repo</th><th class=\"px-4 py-2 text-left\">Status</th><th class=\"px-4 py-2 text-left\">Phase</th><th class=\"px-4 py-2 text-left\">Questions Asked</th></tr></thead> <tbody>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if len(planning) == 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<tr><td colspan=\"5\" class=\"px-4 py-8 text-center text-gray-500\">No active planning sessions</td></tr>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			for _, entry := range planning {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<tr class=\"border-t border-gray-200 dark:border-gray-700\"><td class=\"px-4 py-2\"><a href=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var9 templ.SafeURL
-				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("/issues/%s/%d", entry.Repo, entry.IssueID)))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 91, Col: 90}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" class=\"text-blue-500 hover:underline\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var10 string
-				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Identifier())
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 92, Col: 31}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</a></td><td class=\"px-4 py-2\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var11 string
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Repo)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 95, Col: 43}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</td><td class=\"px-4 py-2\"><span class=\"px-2 py-1 text-xs font-medium rounded-full bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200\">Planning</span></td><td class=\"px-4 py-2\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var12 string
-				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Phase)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 99, Col: 44}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</td><td class=\"px-4 py-2\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var13 string
-				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.QuestionsAsked))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 100, Col: 72}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</td></tr>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</tbody></table></div></div><!-- Retry Queue Table --><div class=\"bg-white dark:bg-gray-800 rounded-lg shadow\"><div class=\"px-4 py-3 border-b border-gray-200 dark:border-gray-700\"><h2 class=\"text-lg font-semibold\">Retry Queue</h2></div><div class=\"overflow-x-auto\"><table class=\"w-full text-sm\"><thead class=\"bg-gray-50 dark:bg-gray-700\"><tr><th class=\"px-4 py-2 text-left\">Issue</th><th class=\"px-4 py-2 text-left\">Attempt</th><th class=\"px-4 py-2 text-left\">Next Retry</th><th class=\"px-4 py-2 text-left\">Error</th></tr></thead> <tbody>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if len(retries) == 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<tr><td colspan=\"4\" class=\"px-4 py-8 text-center text-gray-500\">No retries queued</td></tr>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			for _, entry := range retries {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<tr class=\"border-t border-gray-200 dark:border-gray-700\"><td class=\"px-4 py-2\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var14 string
-				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Identifier)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 131, Col: 49}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</td><td class=\"px-4 py-2\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var15 string
-				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.Attempt))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 132, Col: 65}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</td><td class=\"px-4 py-2\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var16 string
-				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(entry.DueAt.Format("15:04:05"))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 133, Col: 63}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</td><td class=\"px-4 py-2 text-red-500\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var17 string
-				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Error)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 134, Col: 57}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</td></tr>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</tbody></table></div></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
 		templ_7745c5c3_Err = layouts.Base("Dashboard").Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func DashboardContent(running []*domain.RunEntry, retries []*domain.RetryEntry, planning []*domain.PlanningEntry, metrics map[string]int64, maxAgents int) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var3 == nil {
+			templ_7745c5c3_Var3 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<!-- Summary Cards --><div class=\"grid grid-cols-1 md:grid-cols-5 gap-4 mb-6\" id=\"summary-cards\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = SummaryCard("Active Agents", fmt.Sprintf("%d / %d", len(running), maxAgents)).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = SummaryCard("Planning", fmt.Sprintf("%d", len(planning))).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = SummaryCard("Dispatched", fmt.Sprintf("%d", metrics["issues_dispatched"])).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = SummaryCard("Completed", fmt.Sprintf("%d", metrics["issues_completed"])).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = SummaryCard("Failed", fmt.Sprintf("%d", metrics["issues_failed"])).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><!-- Active Agents Table --><div class=\"bg-white dark:bg-gray-800 rounded-lg shadow mb-6\"><div class=\"px-4 py-3 border-b border-gray-200 dark:border-gray-700\"><h2 class=\"text-lg font-semibold\">Active Agents</h2></div><div class=\"overflow-x-auto\"><table class=\"w-full text-sm\"><thead class=\"bg-gray-50 dark:bg-gray-700\"><tr><th class=\"px-4 py-2 text-left\">Issue</th><th class=\"px-4 py-2 text-left\">Repo</th><th class=\"px-4 py-2 text-left\">Status</th><th class=\"px-4 py-2 text-left\">Duration</th><th class=\"px-4 py-2 text-left\">Attempt</th><th class=\"px-4 py-2 text-left\">Last Activity</th></tr></thead> <tbody>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if len(running) == 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<tr><td colspan=\"6\" class=\"px-4 py-8 text-center text-gray-500\">No active agents</td></tr>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		for _, entry := range running {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<tr class=\"border-t border-gray-200 dark:border-gray-700\"><td class=\"px-4 py-2\"><a href=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var4 templ.SafeURL
+			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("/issues/%s/%d", entry.Issue.Repo, entry.Issue.ID)))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 54, Col: 95}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" class=\"text-blue-500 hover:underline\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var5 string
+			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Issue.Identifier())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 55, Col: 35}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</a></td><td class=\"px-4 py-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var6 string
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Issue.Repo)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 58, Col: 47}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</td><td class=\"px-4 py-2\"><span class=\"px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200\">Running</span></td><td class=\"px-4 py-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var7 string
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(FormatDuration(entry.Duration()))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 62, Col: 63}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</td><td class=\"px-4 py-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.Attempt))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 63, Col: 63}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</td><td class=\"px-4 py-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var9 string
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(entry.LastEventAt.Format("15:04:05"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 64, Col: 67}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</td></tr>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</tbody></table></div></div><!-- Planning Sessions Table --><div class=\"bg-white dark:bg-gray-800 rounded-lg shadow mb-6\"><div class=\"px-4 py-3 border-b border-gray-200 dark:border-gray-700\"><h2 class=\"text-lg font-semibold\">Planning Sessions</h2></div><div class=\"overflow-x-auto\"><table class=\"w-full text-sm\"><thead class=\"bg-gray-50 dark:bg-gray-700\"><tr><th class=\"px-4 py-2 text-left\">Issue</th><th class=\"px-4 py-2 text-left\">Repo</th><th class=\"px-4 py-2 text-left\">Status</th><th class=\"px-4 py-2 text-left\">Phase</th><th class=\"px-4 py-2 text-left\">Questions Asked</th></tr></thead> <tbody>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if len(planning) == 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<tr><td colspan=\"5\" class=\"px-4 py-8 text-center text-gray-500\">No active planning sessions</td></tr>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		for _, entry := range planning {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<tr class=\"border-t border-gray-200 dark:border-gray-700\"><td class=\"px-4 py-2\"><a href=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var10 templ.SafeURL
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("/issues/%s/%d", entry.Repo, entry.IssueID)))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 97, Col: 88}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" class=\"text-blue-500 hover:underline\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Identifier())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 98, Col: 29}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</a></td><td class=\"px-4 py-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var12 string
+			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Repo)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 101, Col: 41}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</td><td class=\"px-4 py-2\"><span class=\"px-2 py-1 text-xs font-medium rounded-full bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200\">Planning</span></td><td class=\"px-4 py-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var13 string
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Phase)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 105, Col: 42}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</td><td class=\"px-4 py-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var14 string
+			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.QuestionsAsked))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 106, Col: 70}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</td></tr>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</tbody></table></div></div><!-- Retry Queue Table --><div class=\"bg-white dark:bg-gray-800 rounded-lg shadow\"><div class=\"px-4 py-3 border-b border-gray-200 dark:border-gray-700\"><h2 class=\"text-lg font-semibold\">Retry Queue</h2></div><div class=\"overflow-x-auto\"><table class=\"w-full text-sm\"><thead class=\"bg-gray-50 dark:bg-gray-700\"><tr><th class=\"px-4 py-2 text-left\">Issue</th><th class=\"px-4 py-2 text-left\">Attempt</th><th class=\"px-4 py-2 text-left\">Next Retry</th><th class=\"px-4 py-2 text-left\">Error</th></tr></thead> <tbody>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if len(retries) == 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<tr><td colspan=\"4\" class=\"px-4 py-8 text-center text-gray-500\">No retries queued</td></tr>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		for _, entry := range retries {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<tr class=\"border-t border-gray-200 dark:border-gray-700\"><td class=\"px-4 py-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var15 string
+			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Identifier)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 137, Col: 47}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</td><td class=\"px-4 py-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var16 string
+			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.Attempt))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 138, Col: 63}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</td><td class=\"px-4 py-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var17 string
+			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(entry.DueAt.Format("15:04:05"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 139, Col: 61}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</td><td class=\"px-4 py-2 text-red-500\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var18 string
+			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Error)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 140, Col: 55}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</td></tr>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</tbody></table></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -345,38 +382,38 @@ func SummaryCard(title, value string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var18 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var18 == nil {
-			templ_7745c5c3_Var18 = templ.NopComponent
+		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var19 == nil {
+			templ_7745c5c3_Var19 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-blue-500\"><div class=\"text-sm text-gray-500 dark:text-gray-400\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var19 string
-		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 147, Col: 63}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div><div class=\"text-2xl font-bold mt-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div class=\"bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-blue-500\"><div class=\"text-sm text-gray-500 dark:text-gray-400\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var20 string
-		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(value)
+		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 148, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 151, Col: 63}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div><div class=\"text-2xl font-bold mt-1\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var21 string
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(value)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/pages/dashboard.templ`, Line: 152, Col: 46}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
- Fixed dashboard SSE refresh that was replacing the entire page with the literal string "REFRESH"
- Changed from `sse-swap` (innerHTML replacement with event data) to `hx-trigger="sse:agent-update"` + `hx-get="/api/v1/dashboard"` (fetches rendered HTML fragment on SSE event)
- Extracted `DashboardContent` templ component and added `GET /api/v1/dashboard` fragment endpoint

## Test plan
- [x] All existing tests pass (`go test -race ./...`)
- [x] Manual verification: dashboard loads, SSE events trigger HTML swap instead of showing "REFRESH"
- [x] Build succeeds (`task build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)