### PR TITLE
docs: add doc.go package documentation to all internal packages

### DIFF
--- a/internal/agent/doc.go
+++ b/internal/agent/doc.go
@@ -1,0 +1,7 @@
+// Package agent launches and manages AI coding agent subprocesses.
+//
+// It defines the Runner interface for starting and stopping agents, with
+// concrete implementations for Claude Code CLI (ClaudeRunner) and GitHub
+// Copilot CLI (CopilotRunner). Each running agent is tracked as a Session
+// that holds the subprocess PID, cancellation function, and exit status.
+package agent

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,7 @@
+// Package config loads, validates, and watches the gopilot.yaml configuration file.
+//
+// It parses YAML into typed structs covering GitHub credentials, polling intervals,
+// workspace hooks, agent settings, skills directories, dashboard options, and prompt
+// templates. A filesystem watcher supports hot-reload of select settings without
+// restarting the process.
+package config

--- a/internal/doc_test.go
+++ b/internal/doc_test.go
@@ -1,0 +1,172 @@
+package internal_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAllPackagesHaveDocGo verifies that every package under internal/ has a
+// doc.go file with a package-level comment that starts with "Package <name>".
+func TestAllPackagesHaveDocGo(t *testing.T) {
+	packages := []string{
+		"agent",
+		"config",
+		"domain",
+		"github",
+		"logging",
+		"metrics",
+		"orchestrator",
+		"planning",
+		"prompt",
+		"setup",
+		"skills",
+		"web",
+		"workspace",
+	}
+
+	for _, pkg := range packages {
+		pkg := pkg
+		t.Run(pkg, func(t *testing.T) {
+			docPath := filepath.Join(pkg, "doc.go")
+
+			// File must exist.
+			info, err := os.Stat(docPath)
+			if err != nil {
+				t.Fatalf("doc.go missing for package %s: %v", pkg, err)
+			}
+			if info.IsDir() {
+				t.Fatalf("%s is a directory, expected a file", docPath)
+			}
+
+			// Parse the file and check for a package-level doc comment.
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, docPath, nil, parser.ParseComments)
+			if err != nil {
+				t.Fatalf("failed to parse %s: %v", docPath, err)
+			}
+
+			if f.Doc == nil {
+				t.Fatalf("doc.go in %s has no package-level doc comment", pkg)
+			}
+
+			comment := f.Doc.Text()
+			prefix := "Package " + pkg + " "
+			if !strings.HasPrefix(comment, prefix) {
+				// Also allow the comment to end right after the package name with a period or newline.
+				prefixDot := "Package " + pkg + "."
+				if !strings.HasPrefix(comment, prefix) && !strings.HasPrefix(comment, prefixDot) {
+					t.Errorf("doc comment in %s should start with %q, got: %s", pkg, prefix, firstLine(comment))
+				}
+			}
+
+			// Verify it declares the correct package.
+			if f.Name == nil || f.Name.Name != pkg {
+				// Some packages use a different Go package name (e.g., github -> github).
+				// Just verify doc.go has a valid package declaration.
+				if f.Name == nil {
+					t.Errorf("doc.go in %s has no package declaration", pkg)
+				}
+			}
+		})
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// TestDocGoPackageCommentIsComplete checks that doc comments use complete
+// sentences (end with a period).
+func TestDocGoPackageCommentIsComplete(t *testing.T) {
+	packages := []string{
+		"agent",
+		"config",
+		"domain",
+		"github",
+		"logging",
+		"metrics",
+		"orchestrator",
+		"planning",
+		"prompt",
+		"setup",
+		"skills",
+		"web",
+		"workspace",
+	}
+
+	for _, pkg := range packages {
+		pkg := pkg
+		t.Run(pkg, func(t *testing.T) {
+			docPath := filepath.Join(pkg, "doc.go")
+
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, docPath, nil, parser.ParseComments)
+			if err != nil {
+				t.Skipf("cannot parse %s: %v", docPath, err)
+			}
+			if f.Doc == nil {
+				t.Skipf("no doc comment in %s", pkg)
+			}
+
+			comment := strings.TrimSpace(f.Doc.Text())
+			if !strings.HasSuffix(comment, ".") {
+				t.Errorf("doc comment in %s should end with a period", pkg)
+			}
+		})
+	}
+}
+
+// TestDocGoIsMinimal ensures doc.go files contain only the package clause and
+// doc comment (no functions, types, or variables).
+func TestDocGoIsMinimal(t *testing.T) {
+	packages := []string{
+		"agent",
+		"config",
+		"domain",
+		"github",
+		"logging",
+		"metrics",
+		"orchestrator",
+		"planning",
+		"prompt",
+		"setup",
+		"skills",
+		"web",
+		"workspace",
+	}
+
+	for _, pkg := range packages {
+		pkg := pkg
+		t.Run(pkg, func(t *testing.T) {
+			docPath := filepath.Join(pkg, "doc.go")
+
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, docPath, nil, parser.ParseComments)
+			if err != nil {
+				t.Skipf("cannot parse %s: %v", docPath, err)
+			}
+
+			if len(f.Decls) > 0 {
+				for _, decl := range f.Decls {
+					switch d := decl.(type) {
+					case *ast.GenDecl:
+						// Allow import declarations but nothing else.
+						if d.Tok != token.IMPORT {
+							t.Errorf("doc.go in %s should only contain the package clause and doc comment, found %s declaration", pkg, d.Tok)
+						}
+					default:
+						t.Errorf("doc.go in %s should only contain the package clause and doc comment, found unexpected declaration", pkg)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/domain/doc.go
+++ b/internal/domain/doc.go
@@ -1,0 +1,7 @@
+// Package domain defines the core types used throughout Gopilot.
+//
+// It contains normalized representations of GitHub issues, active run entries
+// for agent sessions, completed run history, retry queue entries, token usage
+// tracking, planning entries, and agent events. Business logic such as issue
+// eligibility checks and priority sorting lives here as well.
+package domain

--- a/internal/github/doc.go
+++ b/internal/github/doc.go
@@ -1,0 +1,6 @@
+// Package github provides REST and GraphQL clients for GitHub API operations.
+//
+// The Client interface abstracts issue fetching, label management, comment
+// posting, project status updates, and sub-issue creation. RESTClient and
+// GraphQLClient implement these operations while tracking API rate limits.
+package github

--- a/internal/logging/doc.go
+++ b/internal/logging/doc.go
@@ -1,0 +1,6 @@
+// Package logging configures structured JSON logging for Gopilot.
+//
+// It sets up slog with a JSON handler writing to stderr and an optional log
+// file, and provides helper functions to create loggers pre-filled with
+// issue context fields.
+package logging

--- a/internal/metrics/doc.go
+++ b/internal/metrics/doc.go
@@ -1,0 +1,6 @@
+// Package metrics tracks token usage, cost estimation, and duration statistics.
+//
+// TokenTracker aggregates input and output token counts per issue and in total.
+// Counters provides generic counter and duration recording for operational
+// metrics. Cost estimation uses per-model pricing tables.
+package metrics

--- a/internal/orchestrator/doc.go
+++ b/internal/orchestrator/doc.go
@@ -1,0 +1,7 @@
+// Package orchestrator implements the poll-dispatch-reconcile loop that drives Gopilot.
+//
+// It polls GitHub for eligible issues, claims and dispatches them to agent
+// sessions in isolated workspaces, monitors running agents for completion or
+// staleness, retries failed runs with exponential backoff, and reconciles
+// state when issues become terminal or ineligible.
+package orchestrator

--- a/internal/planning/doc.go
+++ b/internal/planning/doc.go
@@ -1,0 +1,7 @@
+// Package planning manages interactive WebSocket-based planning sessions.
+//
+// Users and agents collaborate in real-time chat to propose, review, and
+// approve implementation plans before work begins. The package handles
+// session lifecycle, message accumulation, plan parsing from markdown,
+// and issue creation from approved plans.
+package planning

--- a/internal/prompt/doc.go
+++ b/internal/prompt/doc.go
@@ -1,0 +1,5 @@
+// Package prompt renders Go text/template prompts for agent execution.
+//
+// It injects issue metadata, attempt numbers, and loaded skills into prompt
+// templates that are passed to agent subprocesses as their initial instructions.
+package prompt

--- a/internal/setup/doc.go
+++ b/internal/setup/doc.go
@@ -1,0 +1,5 @@
+// Package setup bootstraps required GitHub labels on configured repositories.
+//
+// It ensures all Gopilot-managed labels exist with the correct name, color,
+// and description, creating or updating them as needed.
+package setup

--- a/internal/skills/doc.go
+++ b/internal/skills/doc.go
@@ -1,0 +1,7 @@
+// Package skills loads SKILL.md files and injects them into agent prompts.
+//
+// Skills are markdown documents with YAML frontmatter that define reusable
+// instructions for agents. This package discovers skill files from configured
+// directories, parses their metadata and content, and formats them for
+// inclusion in rendered prompts.
+package skills

--- a/internal/web/doc.go
+++ b/internal/web/doc.go
@@ -1,0 +1,7 @@
+// Package web provides the HTTP dashboard server and real-time event streaming.
+//
+// It builds a chi router with REST endpoints for health, state, and metrics,
+// an SSE hub for live dashboard updates, and WebSocket integration for
+// planning sessions. Provider interfaces abstract state access to avoid
+// circular imports with the orchestrator.
+package web

--- a/internal/workspace/doc.go
+++ b/internal/workspace/doc.go
@@ -1,0 +1,6 @@
+// Package workspace manages per-issue workspace directories and lifecycle hooks.
+//
+// The Manager interface defines operations for creating isolated directories,
+// executing shell hooks (after_create, before_run, after_run, before_remove)
+// with variable interpolation, and cleaning up after agent completion.
+package workspace


### PR DESCRIPTION
## Summary

- Added `doc.go` files with Godoc-convention package comments to all 13 internal packages
- Each comment starts with `Package <name>` and describes the package's purpose in complete sentences
- Added tests verifying doc.go presence, comment format, and file minimality

## Packages documented

`agent`, `config`, `domain`, `github`, `logging`, `metrics`, `orchestrator`, `planning`, `prompt`, `setup`, `skills`, `web`, `workspace`

## Test plan

- [x] `TestAllPackagesHaveDocGo` — verifies each package has a parseable doc.go with correct `Package <name>` prefix
- [x] `TestDocGoPackageCommentIsComplete` — verifies comments end with a period
- [x] `TestDocGoIsMinimal` — verifies doc.go contains only the package clause and comment
- [x] Full test suite passes with `-race`
- [x] `go doc ./internal/<pkg>` produces meaningful output for every package

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)