### PR TITLE
feat: accept context.Context in config Watch()

### DIFF
--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"log/slog"
 
 	"github.com/fsnotify/fsnotify"
@@ -12,7 +13,7 @@ type Watcher struct {
 	fsw *fsnotify.Watcher
 }
 
-func Watch(path string, cb ReloadCallback) (*Watcher, error) {
+func Watch(ctx context.Context, path string, cb ReloadCallback) (*Watcher, error) {
 	fsw, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
@@ -24,8 +25,11 @@ func Watch(path string, cb ReloadCallback) (*Watcher, error) {
 	}
 
 	go func() {
+		defer fsw.Close()
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case event, ok := <-fsw.Events:
 				if !ok {
 					return

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -8,11 +9,7 @@ import (
 	"time"
 )
 
-func TestWatcherDetectsChange(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "gopilot.yaml")
-
-	yaml := `
+const testYAML = `
 github:
   token: test-token
   repos: [owner/repo]
@@ -22,10 +19,17 @@ agent: {command: copilot}
 workspace: {root: /tmp}
 polling: {interval_ms: 30000}
 `
-	os.WriteFile(path, []byte(yaml), 0644)
+
+func TestWatcherDetectsChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gopilot.yaml")
+	os.WriteFile(path, []byte(testYAML), 0644)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	var reloadCount atomic.Int32
-	w, err := Watch(path, func(cfg *Config, err error) {
+	w, err := Watch(ctx, path, func(cfg *Config, err error) {
 		reloadCount.Add(1)
 	})
 	if err != nil {
@@ -51,5 +55,64 @@ polling: {interval_ms: 15000}
 
 	if reloadCount.Load() < 1 {
 		t.Error("expected at least 1 reload callback")
+	}
+}
+
+func TestWatcherStopsOnContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gopilot.yaml")
+	os.WriteFile(path, []byte(testYAML), 0644)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var reloadCount atomic.Int32
+	w, err := Watch(ctx, path, func(cfg *Config, err error) {
+		reloadCount.Add(1)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Cancel the context to stop the watcher goroutine.
+	cancel()
+	time.Sleep(100 * time.Millisecond)
+
+	// Write after cancel — callback should NOT fire.
+	newYaml := `
+github:
+  token: test-token
+  repos: [owner/repo]
+  project: {owner: "@me", number: 1}
+  eligible_labels: [gopilot]
+agent: {command: copilot}
+workspace: {root: /tmp}
+polling: {interval_ms: 15000}
+`
+	os.WriteFile(path, []byte(newYaml), 0644)
+	time.Sleep(500 * time.Millisecond)
+
+	if reloadCount.Load() != 0 {
+		t.Errorf("expected 0 reload callbacks after context cancel, got %d", reloadCount.Load())
+	}
+}
+
+func TestWatcherCloseStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gopilot.yaml")
+	os.WriteFile(path, []byte(testYAML), 0644)
+
+	ctx := context.Background()
+
+	w, err := Watch(ctx, path, func(cfg *Config, err error) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Close() should still work as an alternative shutdown mechanism.
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close() returned error: %v", err)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -74,7 +74,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	)
 
 	if o.configPath != "" {
-		watcher, err := config.Watch(o.configPath, func(newCfg *config.Config, loadErr error) {
+		watcher, err := config.Watch(ctx, o.configPath, func(newCfg *config.Config, loadErr error) {
 			if loadErr != nil {
 				slog.Error("config reload failed, keeping current config", "error", loadErr)
 				return


### PR DESCRIPTION
## Summary
- `config.Watch()` now accepts `context.Context` as its first parameter
- Internal goroutine exits when context is cancelled, enabling graceful shutdown
- `Close()` still works as an alternative shutdown mechanism
- Caller in `orchestrator.Run()` threads through its existing context

## Test plan
- [x] `TestWatcherDetectsChange` — existing test updated to use context
- [x] `TestWatcherStopsOnContextCancel` — new test verifying goroutine stops on cancel
- [x] `TestWatcherCloseStillWorks` — new test verifying Close() still functions
- [x] Full test suite passes with `-race`

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)