### PR TITLE
docs: add Example tests for key public APIs

### DIFF
--- a/internal/config/example_test.go
+++ b/internal/config/example_test.go
@@ -1,0 +1,59 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bketelsen/gopilot/internal/config"
+)
+
+func ExampleLoad() {
+	yaml := `github:
+  token: ghp_example_token
+  repos: [owner/my-repo]
+  eligible_labels: [gopilot]
+agent:
+  command: copilot
+workspace:
+  root: /tmp/workspaces`
+
+	dir, _ := os.MkdirTemp("", "example-config")
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "gopilot.yaml")
+	os.WriteFile(path, []byte(yaml), 0644)
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	fmt.Println("repos:", cfg.GitHub.Repos)
+	fmt.Println("agent:", cfg.Agent.Command)
+	fmt.Println("max_retries:", cfg.Agent.MaxRetries)
+	// Output:
+	// repos: [owner/my-repo]
+	// agent: copilot
+	// max_retries: 3
+}
+
+func ExampleConfig_AgentCommandForIssue() {
+	cfg := &config.Config{
+		Agent: config.AgentConfig{
+			Command: "copilot",
+			Overrides: []config.AgentOverride{
+				{Repos: []string{"owner/special-repo"}, Command: "claude"},
+				{Labels: []string{"use-claude"}, Command: "claude"},
+			},
+		},
+	}
+
+	fmt.Println(cfg.AgentCommandForIssue("owner/normal-repo", nil))
+	fmt.Println(cfg.AgentCommandForIssue("owner/special-repo", nil))
+	fmt.Println(cfg.AgentCommandForIssue("owner/normal-repo", []string{"use-claude"}))
+	// Output:
+	// copilot
+	// claude
+	// claude
+}

--- a/internal/domain/example_test.go
+++ b/internal/domain/example_test.go
@@ -1,0 +1,39 @@
+package domain_test
+
+import (
+	"fmt"
+
+	"github.com/bketelsen/gopilot/internal/domain"
+)
+
+func ExampleIssue_IsEligible() {
+	issue := domain.Issue{
+		ID:     42,
+		Repo:   "owner/repo",
+		Labels: []string{"gopilot", "bug"},
+		Status: "Todo",
+	}
+
+	eligible := []string{"gopilot"}
+	excluded := []string{"blocked"}
+
+	fmt.Println(issue.IsEligible(eligible, excluded))
+
+	issue.Labels = []string{"blocked"}
+	fmt.Println(issue.IsEligible(eligible, excluded))
+	// Output:
+	// true
+	// false
+}
+
+func ExampleParseBlockedBy() {
+	body := `This task depends on other work.
+Blocked by #10
+Also blocked by #25
+Unrelated text here.`
+
+	blockers := domain.ParseBlockedBy(body)
+	fmt.Println(blockers)
+	// Output:
+	// [10 25]
+}

--- a/internal/metrics/example_test.go
+++ b/internal/metrics/example_test.go
@@ -1,0 +1,24 @@
+package metrics_test
+
+import (
+	"fmt"
+
+	"github.com/bketelsen/gopilot/internal/metrics"
+)
+
+func ExampleTokenTracker_Record() {
+	tracker := metrics.NewTokenTracker()
+
+	tracker.Record(42, metrics.TokenUsage{InputTokens: 1000, OutputTokens: 500})
+	tracker.Record(42, metrics.TokenUsage{InputTokens: 2000, OutputTokens: 1000})
+	tracker.Record(99, metrics.TokenUsage{InputTokens: 500, OutputTokens: 250})
+
+	issue42 := tracker.ForIssue(42)
+	fmt.Printf("Issue 42: input=%d output=%d\n", issue42.InputTokens, issue42.OutputTokens)
+
+	totals := tracker.Totals()
+	fmt.Printf("Totals: input=%d output=%d\n", totals.InputTokens, totals.OutputTokens)
+	// Output:
+	// Issue 42: input=3000 output=1500
+	// Totals: input=3500 output=1750
+}

--- a/internal/orchestrator/example_test.go
+++ b/internal/orchestrator/example_test.go
@@ -1,0 +1,22 @@
+package orchestrator_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bketelsen/gopilot/internal/orchestrator"
+)
+
+func ExampleBackoffDelay() {
+	maxBackoff := 5 * time.Minute
+
+	fmt.Println(orchestrator.BackoffDelay(1, maxBackoff))
+	fmt.Println(orchestrator.BackoffDelay(2, maxBackoff))
+	fmt.Println(orchestrator.BackoffDelay(3, maxBackoff))
+	fmt.Println(orchestrator.BackoffDelay(5, maxBackoff))
+	// Output:
+	// 20s
+	// 40s
+	// 1m20s
+	// 5m0s
+}

--- a/internal/prompt/example_test.go
+++ b/internal/prompt/example_test.go
@@ -1,0 +1,28 @@
+package prompt_test
+
+import (
+	"fmt"
+
+	"github.com/bketelsen/gopilot/internal/domain"
+	"github.com/bketelsen/gopilot/internal/prompt"
+)
+
+func ExampleRender() {
+	tmpl := `Fix {{.Issue.Repo}}#{{.Issue.ID}}: {{.Issue.Title}} (attempt {{.Attempt}})`
+
+	issue := domain.Issue{
+		ID:    42,
+		Repo:  "owner/repo",
+		Title: "Fix login bug",
+	}
+
+	result, err := prompt.Render(tmpl, issue, 1, "")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	fmt.Println(result)
+	// Output:
+	// Fix owner/repo#42: Fix login bug (attempt 1)
+}

--- a/internal/skills/example_test.go
+++ b/internal/skills/example_test.go
@@ -1,0 +1,38 @@
+package skills_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bketelsen/gopilot/internal/skills"
+)
+
+func ExampleLoadFromDir() {
+	dir, _ := os.MkdirTemp("", "example-skills")
+	defer os.RemoveAll(dir)
+
+	skillDir := filepath.Join(dir, "tdd")
+	os.MkdirAll(skillDir, 0755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: tdd
+description: Test-driven development workflow
+type: rigid
+---
+
+Write tests before implementation.`), 0644)
+
+	loaded, err := skills.LoadFromDir(dir)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	fmt.Println("count:", len(loaded))
+	fmt.Println("name:", loaded[0].Name)
+	fmt.Println("type:", loaded[0].Type)
+	// Output:
+	// count: 1
+	// name: tdd
+	// type: rigid
+}


### PR DESCRIPTION
## Summary
- Add **8 `func Example*` tests** across 6 packages (`config`, `domain`, `skills`, `prompt`, `metrics`, `orchestrator`)
- All examples include `// Output:` comments so they function as verified tests
- Examples serve as both runnable tests and `go doc` documentation

### Examples added
| Package | Example | Purpose |
|---------|---------|---------|
| `config` | `ExampleLoad` | Loading and accessing config values |
| `config` | `ExampleConfig_AgentCommandForIssue` | Agent selection by label/repo override |
| `domain` | `ExampleIssue_IsEligible` | Issue eligibility checking |
| `domain` | `ExampleParseBlockedBy` | Extracting blocked-by references from body |
| `skills` | `ExampleLoadFromDir` | Loading skill files from a directory |
| `prompt` | `ExampleRender` | Rendering a prompt template with issue data |
| `metrics` | `ExampleTokenTracker_Record` | Token tracking and per-issue accumulation |
| `orchestrator` | `ExampleBackoffDelay` | Exponential backoff calculation |

Closes #13

## Test plan
- [x] All 8 example tests compile and pass (`go test -race ./...`)
- [x] Full test suite passes with no regressions
- [x] Examples include `// Output:` comments for verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)